### PR TITLE
Chore: removed account set methods

### DIFF
--- a/framework/star_frame/src/account_set/impls/account_info.rs
+++ b/framework/star_frame/src/account_set/impls/account_info.rs
@@ -8,36 +8,8 @@ use solana_program::pubkey::Pubkey;
 use star_frame::account_set::{AccountSet, AccountSetCleanup, AccountSetValidate};
 use std::cell::{Ref, RefMut};
 
-impl<'info> AccountSet<'info> for AccountInfo<'info> {
-    fn try_to_accounts<'a, E>(
-        &'a self,
-        mut add_account: impl FnMut(&'a AccountInfo<'info>) -> Result<(), E>,
-    ) -> Result<(), E>
-    where
-        'info: 'a,
-    {
-        add_account(self)
-    }
-
-    fn to_account_metas(&self, mut add_account_meta: impl FnMut(AccountMeta)) {
-        add_account_meta(self.account_meta());
-    }
-}
-impl<'__a, 'info> AccountSet<'info> for &'__a AccountInfo<'info> {
-    fn try_to_accounts<'a, E>(
-        &'a self,
-        mut add_account: impl FnMut(&'a AccountInfo<'info>) -> Result<(), E>,
-    ) -> Result<(), E>
-    where
-        'info: 'a,
-    {
-        add_account(self)
-    }
-
-    fn to_account_metas(&self, mut add_account_meta: impl FnMut(AccountMeta)) {
-        add_account_meta(self.account_meta());
-    }
-}
+impl<'info> AccountSet<'info> for AccountInfo<'info> {}
+impl<'__a, 'info> AccountSet<'info> for &'__a AccountInfo<'info> {}
 impl<'info> SingleAccountSet<'info> for AccountInfo<'info> {
     fn account_info(&self) -> &AccountInfo<'info> {
         self

--- a/framework/star_frame/src/account_set/impls/array.rs
+++ b/framework/star_frame/src/account_set/impls/array.rs
@@ -3,31 +3,8 @@ use crate::syscalls::SyscallInvoke;
 use crate::Result;
 use array_init::try_array_init;
 use solana_program::account_info::AccountInfo;
-use solana_program::instruction::AccountMeta;
 
-impl<'info, A, const N: usize> AccountSet<'info> for [A; N]
-where
-    A: AccountSet<'info>,
-{
-    fn try_to_accounts<'a, E>(
-        &'a self,
-        mut add_account: impl FnMut(&'a AccountInfo<'info>) -> Result<(), E>,
-    ) -> Result<(), E>
-    where
-        'info: 'a,
-    {
-        for a in self {
-            a.try_to_accounts(&mut add_account)?;
-        }
-        Ok(())
-    }
-
-    fn to_account_metas(&self, mut add_account_meta: impl FnMut(AccountMeta)) {
-        for a in self {
-            a.to_account_metas(&mut add_account_meta);
-        }
-    }
-}
+impl<'info, A, const N: usize> AccountSet<'info> for [A; N] where A: AccountSet<'info> {}
 
 impl<'a, 'info, A, const N: usize, DArg> AccountSetDecode<'a, 'info, [DArg; N]> for [A; N]
 where

--- a/framework/star_frame/src/account_set/impls/option.rs
+++ b/framework/star_frame/src/account_set/impls/option.rs
@@ -3,34 +3,10 @@ use crate::syscalls::SyscallInvoke;
 use crate::Result;
 use anyhow::bail;
 use solana_program::account_info::AccountInfo;
-use solana_program::instruction::AccountMeta;
 use solana_program::msg;
 use solana_program::program_error::ProgramError;
 
-impl<'info, A> AccountSet<'info> for Option<A>
-where
-    A: AccountSet<'info>,
-{
-    fn try_to_accounts<'a, E>(
-        &'a self,
-        add_account: impl FnMut(&'a AccountInfo<'info>) -> crate::Result<(), E>,
-    ) -> crate::Result<(), E>
-    where
-        'info: 'a,
-    {
-        if let Some(s) = self {
-            s.try_to_accounts(add_account)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn to_account_metas(&self, add_account_meta: impl FnMut(AccountMeta)) {
-        if let Some(s) = self {
-            s.to_account_metas(add_account_meta);
-        }
-    }
-}
+impl<'info, A> AccountSet<'info> for Option<A> where A: AccountSet<'info> {}
 
 impl<'a, 'info, A, DArg> AccountSetDecode<'a, 'info, Option<DArg>> for Option<A>
 where

--- a/framework/star_frame/src/account_set/impls/phantom_data.rs
+++ b/framework/star_frame/src/account_set/impls/phantom_data.rs
@@ -2,25 +2,9 @@ use crate::account_set::{AccountSet, AccountSetCleanup, AccountSetDecode, Accoun
 use crate::syscalls::SyscallInvoke;
 use crate::Result;
 use solana_program::account_info::AccountInfo;
-use solana_program::instruction::AccountMeta;
 use std::marker::PhantomData;
 
-impl<'info, T> AccountSet<'info> for PhantomData<T>
-where
-    T: ?Sized,
-{
-    fn try_to_accounts<'a, E>(
-        &'a self,
-        _add_account: impl FnMut(&'a AccountInfo<'info>) -> crate::Result<(), E>,
-    ) -> Result<(), E>
-    where
-        'info: 'a,
-    {
-        Ok(())
-    }
-
-    fn to_account_metas(&self, _add_account_meta: impl FnMut(AccountMeta)) {}
-}
+impl<'info, T> AccountSet<'info> for PhantomData<T> where T: ?Sized {}
 impl<'a, 'info, T> AccountSetDecode<'a, 'info, ()> for PhantomData<T>
 where
     T: ?Sized,

--- a/framework/star_frame/src/account_set/impls/unit.rs
+++ b/framework/star_frame/src/account_set/impls/unit.rs
@@ -2,21 +2,8 @@ use crate::account_set::{AccountSet, AccountSetCleanup, AccountSetDecode, Accoun
 use crate::syscalls::SyscallInvoke;
 use crate::Result;
 use solana_program::account_info::AccountInfo;
-use solana_program::instruction::AccountMeta;
 
-impl<'info> AccountSet<'info> for () {
-    fn try_to_accounts<'a, E>(
-        &'a self,
-        _add_account: impl FnMut(&'a AccountInfo<'info>) -> Result<(), E>,
-    ) -> Result<(), E>
-    where
-        'info: 'a,
-    {
-        Ok(())
-    }
-
-    fn to_account_metas(&self, _add_account_meta: impl FnMut(AccountMeta)) {}
-}
+impl<'info> AccountSet<'info> for () {}
 impl<'a, 'info> AccountSetDecode<'a, 'info, ()> for () {
     fn decode_accounts(
         _accounts: &mut &'a [AccountInfo],

--- a/framework/star_frame/src/account_set/impls/vec.rs
+++ b/framework/star_frame/src/account_set/impls/vec.rs
@@ -3,32 +3,9 @@ use crate::syscalls::SyscallInvoke;
 use crate::Result;
 use anyhow::bail;
 use solana_program::account_info::AccountInfo;
-use solana_program::instruction::AccountMeta;
 use solana_program::program_error::ProgramError;
 
-impl<'info, T> AccountSet<'info> for Vec<T>
-where
-    T: AccountSet<'info>,
-{
-    fn try_to_accounts<'a, E>(
-        &'a self,
-        mut add_account: impl FnMut(&'a AccountInfo<'info>) -> crate::Result<(), E>,
-    ) -> crate::Result<(), E>
-    where
-        'info: 'a,
-    {
-        for acc in self {
-            acc.try_to_accounts(&mut add_account)?;
-        }
-        Ok(())
-    }
-
-    fn to_account_metas(&self, mut add_account_meta: impl FnMut(AccountMeta)) {
-        for acc in self {
-            acc.to_account_metas(&mut add_account_meta);
-        }
-    }
-}
+impl<'info, T> AccountSet<'info> for Vec<T> where T: AccountSet<'info> {}
 impl<'a, 'info, T> AccountSetDecode<'a, 'info, usize> for Vec<T>
 where
     T: AccountSetDecode<'a, 'info, ()>,

--- a/framework/star_frame/src/account_set/mod.rs
+++ b/framework/star_frame/src/account_set/mod.rs
@@ -22,49 +22,12 @@ use solana_program::instruction::AccountMeta;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use std::cell::{Ref, RefMut};
-use std::convert::Infallible;
 use std::slice;
 
 /// A set of accounts that can be used as input to an instruction.
 pub trait AccountSet<'info> {
     /// Sets account cache
     fn set_account_cache(&mut self, _syscalls: &mut impl SyscallAccountCache<'info>) {}
-
-    fn try_to_accounts<'a, E>(
-        &'a self,
-        add_account: impl FnMut(&'a AccountInfo<'info>) -> Result<(), E>,
-    ) -> Result<(), E>
-    where
-        'info: 'a;
-
-    /// Add all the accounts in this set using `add_account`.
-    fn to_accounts<'a>(&'a self, mut add_account: impl FnMut(&'a AccountInfo<'info>))
-    where
-        'info: 'a,
-    {
-        self.try_to_accounts::<Infallible>(|a| {
-            add_account(a);
-            Ok(())
-        })
-        .unwrap();
-    }
-
-    /// Gets a vector of all the accounts in this set.
-    fn to_accounts_vec<'a>(&'a self) -> Vec<&'a AccountInfo<'info>> {
-        let mut out = Vec::new();
-        self.to_accounts(|acc| out.push(acc));
-        out
-    }
-
-    /// Add all accounts in this set using `add_account_meta`.
-    fn to_account_metas(&self, add_account_meta: impl FnMut(AccountMeta));
-
-    /// Gets a vector of all the account metas in this set.
-    fn to_account_metas_vec(&self) -> Vec<AccountMeta> {
-        let mut out = Vec::new();
-        self.to_account_metas(|acc| out.push(acc));
-        out
-    }
 }
 
 /// Convenience methods for decoding and validating a list of [`AccountInfo`]s to an [`AccountSet`]. Performs

--- a/framework/star_frame_proc/src/account_set/generics.rs
+++ b/framework/star_frame_proc/src/account_set/generics.rs
@@ -1,4 +1,4 @@
-use crate::util::{new_generic, new_lifetime};
+use crate::util::new_generic;
 use proc_macro2::{Ident, Span};
 use std::collections::HashMap;
 use syn::{GenericParam, Generics, Lifetime, LifetimeParam};
@@ -10,7 +10,6 @@ pub struct AccountSetGenerics {
     pub decode_generics: Generics,
     pub info_lifetime: Lifetime,
     pub decode_lifetime: Lifetime,
-    pub function_lifetime: Lifetime,
     pub function_generic_type: Ident,
 }
 
@@ -27,7 +26,6 @@ pub fn account_set_generics(generics: Generics) -> AccountSetGenerics {
             LifetimeParam::new(Lifetime::new("'info", Span::call_site()))
         })
         .clone();
-    let function_lifetime = new_lifetime(&generics);
     let function_generic_type = new_generic(&generics);
     let mut decode_lifetimes = lifetimes.clone();
     let mut add_decode = false;
@@ -61,7 +59,6 @@ pub fn account_set_generics(generics: Generics) -> AccountSetGenerics {
         decode_generics,
         info_lifetime: info_lifetime.lifetime,
         decode_lifetime: decode_lifetime.lifetime,
-        function_lifetime,
         function_generic_type,
     }
 }

--- a/framework/star_frame_proc/src/account_set/struct_impl/mod.rs
+++ b/framework/star_frame_proc/src/account_set/struct_impl/mod.rs
@@ -67,7 +67,6 @@ pub(super) fn derive_account_set_impl_struct(
         main_generics,
         other_generics,
         info_lifetime,
-        function_lifetime,
         function_generic_type,
         ..
     } = &account_set_generics;
@@ -75,7 +74,6 @@ pub(super) fn derive_account_set_impl_struct(
     let Paths {
         account_info,
         account_set,
-        crate_name,
         macro_prelude,
         result,
         ..
@@ -449,31 +447,6 @@ pub(super) fn derive_account_set_impl_struct(
             ) {
                 #set_account_caches
                 #(<#field_type as #account_set<#info_lifetime>>::set_account_cache(&mut self.#field_name, syscalls);)*
-            }
-
-            fn try_to_accounts<#function_lifetime, #function_generic_type>(
-                &#function_lifetime self,
-                mut add_account: impl FnMut(&#function_lifetime #account_info<#info_lifetime>) -> #result<(), #function_generic_type>,
-            ) -> #result<(), #function_generic_type>
-            where
-                #info_lifetime: #function_lifetime,
-            {
-                #(<#field_type as #account_set<#info_lifetime>>::try_to_accounts(&self.#field_name, &mut add_account)?;)*
-                Ok(())
-            }
-
-            fn to_accounts<#function_lifetime>(
-                &#function_lifetime self,
-                mut add_account: impl FnMut(&#function_lifetime #account_info<#info_lifetime>),
-            )
-            where
-                #info_lifetime: #function_lifetime,
-            {
-                #(<#field_type as #account_set<#info_lifetime>>::to_accounts(&self.#field_name, &mut add_account);)*
-            }
-
-            fn to_account_metas(&self, mut add_account_meta: impl FnMut(#crate_name::solana_program::instruction::AccountMeta)) {
-                #(<#field_type as #account_set<#info_lifetime>>::to_account_metas(&self.#field_name, &mut add_account_meta);)*
             }
         }
 

--- a/framework/star_frame_proc/src/util/generics.rs
+++ b/framework/star_frame_proc/src/util/generics.rs
@@ -137,6 +137,7 @@ impl CombineGenerics for Generics {
     }
 }
 
+#[allow(dead_code)]
 pub fn new_lifetime<G: GetGenerics>(generics: &G) -> Lifetime {
     let mut lifetime = "l".to_string();
     while generics


### PR DESCRIPTION
The account set methods being removed were sorta client-like helper functions, but didn't fully make sense. They will be replaced at some point with client stuff similar to anchor with separate structs that take in only pubkeys/metas 