### PR TITLE
chore: use latest nightly toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # Check https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
 # for valid toolchains.
 # Older ones can be found at https://github.com/oxalica/rust-overlay/tree/master/manifests/nightly
-channel = "nightly-2024-04-28"
+channel = "nightly"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/star_frame/src/unsize/impls/list.rs
+++ b/star_frame/src/unsize/impls/list.rs
@@ -320,7 +320,7 @@ where
             .ok_or_else(|| anyhow::anyhow!("Could not convert list size to usize"))?;
         data.advance(size_of::<T>() * length);
         Ok(ListRef(
-            unsafe { &*ptr::from_raw_parts(ptr.cast(), size_of::<T>() * length) },
+            unsafe { &*ptr::from_raw_parts(ptr, size_of::<T>() * length) },
             PhantomData,
         ))
     }
@@ -333,7 +333,7 @@ where
             .ok_or_else(|| anyhow::anyhow!("Could not convert list size to usize"))?;
         data.try_advance(size_of::<T>() * length)?;
         let list_ptr = ptr::from_mut(unsafe {
-            &mut *ptr::from_raw_parts_mut(length_bytes.as_mut_ptr().cast(), size_of::<T>() * length)
+            &mut *ptr::from_raw_parts_mut(length_bytes.as_mut_ptr(), size_of::<T>() * length)
         });
         Ok(ListMut(list_ptr, PhantomData))
     }

--- a/star_frame/src/unsize/impls/remaining_bytes.rs
+++ b/star_frame/src/unsize/impls/remaining_bytes.rs
@@ -60,7 +60,7 @@ unsafe impl UnsizedType for RemainingBytes {
         let remaining_bytes = data.advance(data.len());
         let ptr = remaining_bytes.as_ptr();
         Ok(RemainingBytesRef(
-            unsafe { &*ptr::from_raw_parts(ptr.cast(), remaining_bytes.len()) },
+            unsafe { &*ptr::from_raw_parts(ptr, remaining_bytes.len()) },
             PhantomData,
         ))
     }
@@ -69,7 +69,7 @@ unsafe impl UnsizedType for RemainingBytes {
         let remaining_bytes = data.advance(data.len());
         let ptr = remaining_bytes.as_mut_ptr();
         Ok(RemainingBytesMut(
-            unsafe { &mut *ptr::from_raw_parts_mut(ptr.cast(), remaining_bytes.len()) },
+            unsafe { &mut *ptr::from_raw_parts_mut(ptr, remaining_bytes.len()) },
             PhantomData,
         ))
     }

--- a/star_frame/src/util.rs
+++ b/star_frame/src/util.rs
@@ -104,7 +104,7 @@ pub mod borsh_bytemuck {
     ) -> std::io::Result<P> {
         let mut buffer = MaybeUninit::<P>::uninit();
         let bytes =
-            unsafe { &mut *ptr::from_raw_parts_mut(buffer.as_mut_ptr().cast(), size_of::<P>()) };
+            unsafe { &mut *ptr::from_raw_parts_mut(buffer.as_mut_ptr(), size_of::<P>()) };
         reader.read_exact(bytes)?;
         bytemuck::checked::try_from_bytes::<P>(bytes)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;


### PR DESCRIPTION
This pull request includes several changes to the `star_frame` project, focusing on removing unnecessary `cast()` calls and updating the Rust toolchain configuration. The most important changes are listed below:

Rust toolchain update:
* [`rust-toolchain.toml`](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL5-R5): Changed the `channel` from a specific nightly version to the default nightly channel.

Code simplification in `star_frame`:
* [`star_frame/src/unsize/impls/list.rs`](diffhunk://#diff-4e90d2c7cbdf8e5c1f7857f77d6044af7dc472a11722b63c709565e43187c37fL323-R323): Removed unnecessary `cast()` calls in the `from_raw_parts` and `from_raw_parts_mut` functions. [[1]](diffhunk://#diff-4e90d2c7cbdf8e5c1f7857f77d6044af7dc472a11722b63c709565e43187c37fL323-R323) [[2]](diffhunk://#diff-4e90d2c7cbdf8e5c1f7857f77d6044af7dc472a11722b63c709565e43187c37fL336-R336)
* [`star_frame/src/unsize/impls/remaining_bytes.rs`](diffhunk://#diff-5275fa1baad722adc5d79988f0a228c3e66988e4612af627c3a923a0d0f04b05L63-R63): Simplified the `from_raw_parts` and `from_raw_parts_mut` functions by removing unnecessary `cast()` calls. [[1]](diffhunk://#diff-5275fa1baad722adc5d79988f0a228c3e66988e4612af627c3a923a0d0f04b05L63-R63) [[2]](diffhunk://#diff-5275fa1baad722adc5d79988f0a228c3e66988e4612af627c3a923a0d0f04b05L72-R72)
* [`star_frame/src/util.rs`](diffhunk://#diff-70794384d15e1b85f2c951222ce2ff29ee64e9f5f035effeccfd95c696a01207L107-R107): Removed the `cast()` call in the `from_raw_parts_mut` function within the `borsh_bytemuck` module.