### PR TITLE
fix: lock "half" dependency version due to rust 1.79.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
 dependencies = [
  "cfg-if",
  "crunchy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ derivative = "2.2.0"
 derive_more = { version = "2.0.1", features = ["full"] }
 easy_proc = "0.4.0"
 fixed = "=1.26.0"
-half = "2.4.0"
+half = "=2.4.0"
 heck = "0.5.0"
 itertools = "0.14.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION
crates depending on star_frame_state workspace will error using nightly-2024-04-28 (1.79.0-nightly):
```
error: rustc 1.79.0-nightly is not supported by the following package:
  half@2.5.0 requires rustc 1.81
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.79.0-nightly
```
locking half to =2.4.0 fixes it. ^2.4.1 using rust 1.81.0 and newer.
it's the reason `fixed = "=1.26.0" as well, anything newer uses half >2.4.0 ... so just aligning it all.