### PR TITLE
chore: use sa-runners

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -4,7 +4,8 @@ on: pull_request_target
 
 jobs:
   auto-approve:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: sa-runners
     permissions:
       pull-requests: write
     if: github.actor == 'dependabot[bot]'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on:
-      group: star-atlas-large-runners
+      group: sa-runners
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-binaries
@@ -20,7 +20,7 @@ jobs:
 
   lint:
     runs-on:
-      group: star-atlas-large-runners
+      group: sa-runners
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-binaries
@@ -31,7 +31,7 @@ jobs:
 
   fmt:
     runs-on:
-      group: star-atlas-large-runners
+      group: sa-runners
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-binaries
@@ -42,7 +42,7 @@ jobs:
 
   test:
     runs-on:
-      group: star-atlas-large-runners
+      group: sa-runners
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-binaries


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to update the runner group used for various jobs. The most important changes involve modifying the `runs-on` configuration to use the `sa-runners` group instead of the previously specified groups.

Changes to runner group configuration:

* [`.github/workflows/auto-approve.yml`](diffhunk://#diff-283c890e639e6172004c41edb7d2cce76c882feb45e9135b4dce5dc1e82f0c83L7-R8): Updated the `runs-on` configuration for the `auto-approve` job to use the `sa-runners` group.
* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L12-R12): Updated the `runs-on` configuration for the `build`, `lint`, `fmt`, and `test` jobs to use the `sa-runners` group. [[1]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L12-R12) [[2]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L23-R23) [[3]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L34-R34) [[4]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L45-R45)