### PR TITLE
Feat: owned type uses sized and consistent underscoring/docs

### DIFF
--- a/example_programs/faction_enlistment/src/lib.rs
+++ b/example_programs/faction_enlistment/src/lib.rs
@@ -161,9 +161,11 @@ pub struct PlayerFactionData {
     pub enlisted_at_timestamp: i64,
     pub faction_id: FactionId,
     pub bump: u8,
+    /// Some docs!
     pub counter: CounterAccountData,
     pub _padding: [u64; 5],
     #[unsized_start]
+    /// Docs for Some fields!!
     some_fields: SomeFields,
 }
 
@@ -277,15 +279,19 @@ mod tests {
 
         let clock_timestamp = mollusk.mollusk.sysvars.clock.unix_timestamp;
         let expected_faction_account = PlayerFactionDataOwned {
-            owner: player_account,
-            enlisted_at_timestamp: clock_timestamp,
-            faction_id,
-            counter: Default::default(),
-            bump,
-            _padding: [0; 5],
+            _sized: PlayerFactionDataSized {
+                owner: player_account,
+                enlisted_at_timestamp: clock_timestamp,
+                faction_id,
+                counter: Default::default(),
+                bump,
+                _padding: [0; 5],
+            },
             some_fields: SomeFieldsOwned {
-                sized1: 10,
-                sized2: 0,
+                _sized: SomeFieldsSized {
+                    sized1: 10,
+                    sized2: 0,
+                },
                 unsized1: SomeUnsizedOwned {
                     unsized1: vec![],
                     unsized2: vec![],

--- a/star_frame/src/unsize/tests/enum_test.rs
+++ b/star_frame/src/unsize/tests/enum_test.rs
@@ -86,7 +86,7 @@ fn unsized_enum_test() -> Result<()> {
     let mut owned = EnumTestStructOwned {
         list_before: vec![],
         enum_test: UnsizedEnumTestOwned::Unsized1(Unsized1Owned {
-            sized: 0,
+            _sized: Unsized1Sized { sized: 0 },
             list: vec![],
         }),
         list_after: vec![],
@@ -124,9 +124,9 @@ fn unsized_enum_test() -> Result<()> {
     let mut enum_test = mut_bytes.enum_test();
     let mut unsized3 = enum_test.set_unsized3(DefaultInit)?;
     owned.enum_test = UnsizedEnumTestOwned::Unsized3(Unsized3Owned {
-        sized: 0.into(),
+        _sized: Unsized3Sized { sized: 0.into() },
         unsized1: Unsized2Owned {
-            sized: 0.into(),
+            _sized: Unsized2Sized { sized: 0.into() },
             list: vec![],
         },
     });
@@ -154,7 +154,7 @@ fn unsized_enum_test() -> Result<()> {
         list: [1, 2, 3, 4, 5].map(Into::into),
     })?;
     owned.enum_test = UnsizedEnumTestOwned::Unsized2(Unsized2Owned {
-        sized: 426.into(),
+        _sized: Unsized2Sized { sized: 426.into() },
         list: [1, 2, 3, 4, 5].map(Into::into).to_vec(),
     });
     compare_with_owned(&owned, &mut_bytes)?;

--- a/star_frame/src/unsize/tests/struct_test.rs
+++ b/star_frame/src/unsize/tests/struct_test.rs
@@ -183,8 +183,10 @@ impl many_unsized::ManyUnsized {
 fn test_many_unsized() -> Result<()> {
     TestByteSet::<many_unsized::ManyUnsized>::new_default()?;
     let r = TestByteSet::<many_unsized::ManyUnsized>::new(many_unsized::ManyUnsizedOwned {
-        sized1: 1,
-        sized2: 2,
+        _sized: many_unsized::ManyUnsizedSized {
+            sized1: 1,
+            sized2: 2,
+        },
         unsized1: vec![1.into()],
         unsized2: SingleUnsizedOwned { unsized1: vec![2] },
         unsized3: 3,
@@ -193,8 +195,10 @@ fn test_many_unsized() -> Result<()> {
     })?;
     r.data_mut()?.foo()?;
     let expected = ManyUnsizedOwned {
-        sized1: 1,
-        sized2: 2,
+        _sized: many_unsized::ManyUnsizedSized {
+            sized1: 1,
+            sized2: 2,
+        },
         unsized1: vec![1.into(), 2.into()],
         unsized2: SingleUnsizedOwned { unsized1: vec![2] },
         unsized3: 3,
@@ -220,14 +224,14 @@ pub struct SingleUnsizedWithSized {
 fn test_single_unsized_with_sized() -> Result<()> {
     TestByteSet::<SingleUnsizedWithSized>::new_default()?;
     let r = TestByteSet::<SingleUnsizedWithSized>::new(SingleUnsizedWithSizedOwned {
-        sized1: false,
+        _sized: SingleUnsizedWithSizedSized { sized1: false },
         unsized1: vec![1.into()],
     })?;
     let owned = r.owned()?;
     assert_eq!(
         owned,
         SingleUnsizedWithSizedOwned {
-            sized1: false,
+            _sized: SingleUnsizedWithSizedSized { sized1: false },
             unsized1: vec![1.into()],
         }
     );
@@ -250,10 +254,12 @@ pub struct SizedAndUnsized {
 fn test_sized_and_unsized() -> Result<()> {
     TestByteSet::<SizedAndUnsized>::new_default()?;
     let r = TestByteSet::<SizedAndUnsized>::new(SizedAndUnsizedOwned {
-        sized1: true,
-        sized2: 1.into(),
-        sized3: 2,
-        sized4: [3; 10],
+        _sized: SizedAndUnsizedSized {
+            sized1: true,
+            sized2: 1.into(),
+            sized3: 2,
+            sized4: [3; 10],
+        },
         unsized1: vec![4.into()],
         unsized2: vec![TestStruct { val1: 5, val2: 6 }],
         unsized3: 7,
@@ -262,10 +268,12 @@ fn test_sized_and_unsized() -> Result<()> {
     assert_eq!(
         owned,
         SizedAndUnsizedOwned {
-            sized1: true,
-            sized2: 1.into(),
-            sized3: 2,
-            sized4: [3; 10],
+            _sized: SizedAndUnsizedSized {
+                sized1: true,
+                sized2: 1.into(),
+                sized3: 2,
+                sized4: [3; 10],
+            },
             unsized1: vec![4.into()],
             unsized2: vec![TestStruct { val1: 5, val2: 6 }],
             unsized3: 7,
@@ -290,18 +298,22 @@ where
 fn test_with_sized_generics() -> Result<()> {
     TestByteSet::<WithSizedGenerics<TestStruct, bool>>::new_default()?;
     let r = TestByteSet::<WithSizedGenerics<TestStruct, bool>>::new(WithSizedGenericsOwned {
-        sized1: TestStruct { val1: 1, val2: 2 },
-        sized2: true,
-        sized3: 4,
+        _sized: WithSizedGenericsSized {
+            sized1: TestStruct { val1: 1, val2: 2 },
+            sized2: true,
+            sized3: 4,
+        },
         unsized1: vec![TestStruct { val1: 5, val2: 6 }],
     })?;
     let owned = r.owned()?;
     assert_eq!(
         owned,
         WithSizedGenericsOwned {
-            sized1: TestStruct { val1: 1, val2: 2 },
-            sized2: true,
-            sized3: 4,
+            _sized: WithSizedGenericsSized {
+                sized1: TestStruct { val1: 1, val2: 2 },
+                sized2: true,
+                sized3: 4,
+            },
             unsized1: vec![TestStruct { val1: 5, val2: 6 }],
         }
     );
@@ -324,7 +336,10 @@ fn test_with_unsized_generics() -> Result<()> {
     TestByteSet::<WithUnsizedGenerics<PackedValueChecked<u16>, TestStruct>>::new_default()?;
     let r = TestByteSet::<WithUnsizedGenerics<PackedValueChecked<u16>, TestStruct>>::new(
         WithUnsizedGenericsOwned {
-            sized1: 1,
+            _sized: WithUnsizedGenericsSized {
+                sized1: 1,
+                _generics: Default::default(),
+            },
             unsized1: vec![PackedValueChecked(u16::MAX)],
             unsized2: vec![TestStruct { val1: 3, val2: 4 }],
         },
@@ -333,7 +348,10 @@ fn test_with_unsized_generics() -> Result<()> {
     assert_eq!(
         owned,
         WithUnsizedGenericsOwned {
-            sized1: 1,
+            _sized: WithUnsizedGenericsSized {
+                sized1: 1,
+                _generics: Default::default()
+            },
             unsized1: vec![PackedValueChecked(u16::MAX)],
             unsized2: vec![TestStruct { val1: 3, val2: 4 }]
         }
@@ -403,8 +421,11 @@ fn test_with_sized_and_unsized_generics() -> Result<()> {
     let r = TestByteSet::<
         WithSizedAndUnsizedGenerics<TestStruct, PackedValueChecked<u16>, PackedValueChecked<u32>>,
     >::new(WithSizedAndUnsizedGenericsOwned {
-        sized1: TestStruct { val1: 1, val2: 2 },
-        sized2: 3.into(),
+        _sized: WithSizedAndUnsizedGenericsSized {
+            sized1: TestStruct { val1: 1, val2: 2 },
+            sized2: 3.into(),
+            _generics: Default::default(),
+        },
         unsized1: PackedValueChecked(3u16),
         unsized2: vec![5.into()],
     })?;
@@ -413,8 +434,11 @@ fn test_with_sized_and_unsized_generics() -> Result<()> {
     assert_eq!(
         owned,
         WithSizedAndUnsizedGenericsOwned {
-            sized1: TestStruct { val1: 1, val2: 2 },
-            sized2: 3.into(),
+            _sized: WithSizedAndUnsizedGenericsSized {
+                sized1: TestStruct { val1: 1, val2: 2 },
+                sized2: 3.into(),
+                _generics: Default::default(),
+            },
             unsized1: 3.into(),
             unsized2: vec![5.into(), 3.into()],
         }

--- a/star_frame_proc/src/idl/instruction_to_idl.rs
+++ b/star_frame_proc/src/idl/instruction_to_idl.rs
@@ -1,8 +1,8 @@
 use crate::idl::{derive_type_to_idl_inner, TypeToIdlArgs};
-use crate::util::{ignore_cfg_module, reject_attributes, reject_generics, Paths};
+use crate::util::{ignore_cfg_module, new_generic, reject_attributes, reject_generics, Paths};
 use easy_proc::{find_attr, ArgumentList};
-use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote};
+use proc_macro2::TokenStream;
+use quote::quote;
 use syn::{parse_quote, DeriveInput};
 
 pub fn derive_instruction_to_idl(input: &DeriveInput) -> TokenStream {
@@ -28,7 +28,7 @@ pub fn derive_instruction_to_idl(input: &DeriveInput) -> TokenStream {
     let mut generics = input.generics.clone();
     let where_clause = generics.make_where_clause();
 
-    let generic_arg: Ident = format_ident!("__A");
+    let generic_arg = new_generic(&input.generics, None);
 
     where_clause.predicates.push(
         parse_quote!(<Self as #prelude::StarFrameInstruction>::Accounts<'b, 'c>: #prelude::AccountSetToIdl<#generic_arg>),

--- a/star_frame_proc/src/util/generics.rs
+++ b/star_frame_proc/src/util/generics.rs
@@ -195,7 +195,7 @@ pub fn reject_generics(item: &impl GetGenerics, error: Option<&str>) {
 }
 
 pub fn phantom_generics_ident() -> Ident {
-    format_ident!("__generics")
+    format_ident!("_generics")
 }
 
 pub fn phantom_generics_type(item: &impl GetGenerics) -> Option<Type> {


### PR DESCRIPTION
Currently the owned type copies all the fields from sized portion and creates a completely new struct. This is disconnected from how the unsized type is laid out and prevents using methods on sized on owned or using owned as an easy initializer for unsized types.

This is a breaking change and will require updating uses of Owned in programs 