### PR TITLE
Add CLI with project scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,7 +399,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -613,6 +663,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "codama-errors"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +756,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +815,15 @@ name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -908,7 +1023,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1616,6 +1731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,7 +2248,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4525,6 +4652,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "star-frame"
+version = "0.23.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "colored",
+ "convert_case 0.8.0",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "star_frame"
 version = "0.23.1"
 dependencies = [
@@ -4608,6 +4746,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -4959,6 +5103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5138,12 +5288,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5152,7 +5308,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -5161,14 +5326,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5178,10 +5360,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5190,10 +5384,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5202,10 +5408,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5214,10 +5432,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["star_*", "example_programs/*"]
+members = ["star_*", "example_programs/*", "cli"]
 
 [workspace.package]
 version = "0.23.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "star-frame"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+clap = { version = "4.5", features = ["derive", "env"] }
+colored = "2.0"
+anyhow = "1"
+convert_case = "0.8.0"
+solana-pubkey = "2.3.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,65 @@
+use std::process::{Command, Stdio};
+
+use clap::{command, Parser, Subcommand};
+pub mod new_project;
+use new_project::*;
+
+#[derive(Subcommand, Debug)]
+enum CliCommand {
+    #[command(about = "Create new Solana program")]
+    New(NewArgs),
+
+    #[command(about = "Compile/build program")]
+    Build,
+
+    #[command(about = "Execute all tests")]
+    Test(TestArgs),
+}
+
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: CliCommand,
+}
+
+#[derive(Parser, Debug)]
+pub struct TestArgs {
+    /// Show test output (don’t capture stdout/stderr)
+    #[arg(long)]
+    pub nocapture: bool,
+}
+
+pub fn test_project(args: TestArgs) -> anyhow::Result<()> {
+    let mut command = Command::new("cargo");
+    command.arg("test-sbf");
+
+    if args.nocapture {
+        command.arg("--").arg("--nocapture");
+    }
+
+    command
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .expect("Failed to execute command");
+    Ok(())
+}
+
+pub fn build_project() -> anyhow::Result<()> {
+    Command::new("cargo")
+        .arg("build-sbf")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .expect("Failed to execute command");
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        CliCommand::New(args) => new_project(args),
+        CliCommand::Build => build_project(),
+        CliCommand::Test(args) => test_project(args),
+    }
+}

--- a/cli/src/new_project.rs
+++ b/cli/src/new_project.rs
@@ -1,0 +1,75 @@
+use std::{fs, io, path::Path};
+
+use anyhow::anyhow;
+use clap::{arg, Parser};
+use colored::*;
+use convert_case::{Case, Casing};
+use solana_pubkey::Pubkey;
+
+#[derive(Parser, Debug)]
+pub struct NewArgs {
+    ///The name of the program
+    #[arg(value_name = "NAME")]
+    pub name: Option<String>,
+}
+pub fn new_project(args: NewArgs) -> anyhow::Result<()> {
+    let project_name = args
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow!("{}: Project name cannot be empty.", "ERROR".bold().red()))?
+        .to_ascii_lowercase();
+
+    let base = Path::new(&project_name); //Base path
+    let cargo = base.join(".cargo");
+    let src = base.join("src");
+    let ixs = src.join("instructions");
+    let tests = src.join("tests");
+
+    for dir in [&base.canonicalize().unwrap(), &cargo, &src, &ixs, &tests] {
+        fs::create_dir_all(dir)?;
+    }
+
+    // Embed templates
+    const CARGO_TOML: &str = include_str!("template/cargo_toml");
+    const GITIGNORE: &str = include_str!("template/gitignore");
+    const CONFIG_TOML: &str = include_str!("template/config_toml");
+    const LIB_RS: &str = include_str!("template/lib_rs");
+    const STATES_RS: &str = include_str!("template/states_rs");
+    const INCREMENT_RS: &str = include_str!("template/increment_rs");
+    const INITIALIZE_RS: &str = include_str!("template/initialize_rs");
+    const INSTRUCTION_MOD_RS: &str = include_str!("template/instruction_mod_rs");
+    const TEST_RS: &str = include_str!("template/counter_test_rs");
+    const TEST_MOD_RS: &str = include_str!("template/test_mod_rs");
+
+    // Batch-render & write all files
+    let files = [
+        (CARGO_TOML, base.join("Cargo.toml")),
+        (GITIGNORE, base.join(".gitignore")),
+        (CONFIG_TOML, cargo.join("config.toml")),
+        (LIB_RS, src.join("lib.rs")),
+        (STATES_RS, src.join("states.rs")),
+        (INCREMENT_RS, ixs.join("increment.rs")),
+        (INITIALIZE_RS, ixs.join("initialize.rs")),
+        (INSTRUCTION_MOD_RS, ixs.join("mod.rs")),
+        (TEST_RS, tests.join("counter.rs")),
+        (TEST_MOD_RS, tests.join("mod.rs")),
+    ];
+
+    for (template, relative_path) in files {
+        stub_file(template, &base.join(relative_path), &project_name)?;
+    }
+
+    Ok(())
+}
+
+fn stub_file(template: &str, path: &Path, project_name: &String) -> io::Result<()> {
+    let content = template
+        .replace("{name_lowercase}", &project_name.to_ascii_lowercase())
+        .replace("{name_uppercase}", &project_name.to_ascii_uppercase())
+        .replace("{name_pascalcase}", &project_name.to_case(Case::Pascal))
+        .replace("{pubkey}", &Pubkey::new_unique().to_string());
+    fs::write(path, content)?;
+    Ok(())
+}

--- a/cli/src/template/cargo_toml
+++ b/cli/src/template/cargo_toml
@@ -1,0 +1,27 @@
+[package]
+name = "{name_lowercase}"
+description = "Built with Star_Frame"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[package.metadata]
+release.release = false
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "{name_lowercase}"
+
+[features]
+no_entrypoint = []
+idl = ["star_frame/idl"]
+
+[dependencies]
+borsh = { version = "1.5.7", features = ["derive"] }
+bytemuck = { version = "^1.22.0", features = ["extern_crate_std", "min_const_generics", "derive"] }
+star_frame = { version = "0.23.1", features = ["idl"] }
+
+[dev-dependencies]
+codama-nodes = { version = "^0.4.0" }
+mollusk-svm = "0.3.0"
+solana-account = "2.2"

--- a/cli/src/template/config_toml
+++ b/cli/src/template/config_toml
@@ -1,0 +1,2 @@
+[env]
+SBF_OUT_DIR = "target/deploy"

--- a/cli/src/template/counter_test_rs
+++ b/cli/src/template/counter_test_rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+use std::env;
+
+use mollusk_svm::result::Check;
+use mollusk_svm::{program::keyed_account_for_system_program, Mollusk};
+use solana_account::Account as SolanaAccount;
+use star_frame::{client::MakeInstruction, prelude::*, program::StarFrameProgram};
+use crate::states::*;
+use crate::*;
+use star_frame::anyhow;
+
+#[test]
+#[allow(unused)]
+fn program_test() -> Result<()> {
+    if env::var("SBF_OUT_DIR").is_err() {
+        anyhow::bail!("SBF_OUT_DIR is not set");
+    };
+    
+    let mollusk = Mollusk::new(&{name_pascalcase}Program::ID, "{name_lowercase}");
+    let authority = Pubkey::new_unique();
+
+    let start_at = Some(2u64);
+    let seeds = CounterAccountSeeds { authority };
+    let (counter_account, bump) =
+        Pubkey::find_program_address(&seeds.seeds(), &StarFrameDeclaredProgram::ID);
+
+    let mollusk = mollusk.with_context(HashMap::from_iter([
+        (authority, SolanaAccount::new(1_000_000_000, 0, &System::ID)),
+        (counter_account, SolanaAccount::new(0, 0, &System::ID)),
+        keyed_account_for_system_program(),
+    ]));
+
+    let mut expected_counter_state = CounterAccount {
+        authority,
+        count: 2,
+    };
+
+    //Initialize Counter
+    mollusk.process_and_validate_instruction(
+        &{name_pascalcase}Program::instruction(
+            &InitializeCounter { start_at },
+            InitializeClientAccounts {
+                authority,
+                counter: counter_account,
+                system_program: None,
+            },
+        )?,
+        &[
+            Check::success(),
+            Check::account(&counter_account)
+                .data(&CounterAccount::serialize_account(expected_counter_state)?)
+                .owner(&{name_pascalcase}Program::ID)
+                .build(),
+        ],
+    );
+
+    //Increment Counter
+    expected_counter_state.count = 3;
+    mollusk.process_and_validate_instruction(
+        &{name_pascalcase}Program::instruction(
+            &Increment,
+            IncrementClientAccounts {
+                authority,
+                counter: counter_account,
+            },
+        )?,
+        &[Check::account(&counter_account)
+            .data(&CounterAccount::serialize_account(expected_counter_state)?)
+            .build()],
+    );
+
+    Ok(())
+}
+
+//Idl Generation Test
+#[cfg(feature = "idl")]
+#[test]
+fn generate_idl() -> Result<()> {
+    use star_frame::prelude::*;
+    let idl = {name_pascalcase}Program::program_to_idl()?;
+    let codama_idl: ProgramNode = idl.try_into()?;
+    let idl_json = codama_idl.to_json()?;
+    std::fs::write("idl.json", &idl_json)?;
+    Ok(())
+}
+

--- a/cli/src/template/gitignore
+++ b/cli/src/template/gitignore
@@ -1,0 +1,3 @@
+target
+test-ledger
+idl.json

--- a/cli/src/template/increment_rs
+++ b/cli/src/template/increment_rs
@@ -1,0 +1,27 @@
+use crate::states::*;
+use star_frame::prelude::*;
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Copy, Clone, InstructionArgs)]
+pub struct Increment;
+
+#[derive(AccountSet, Debug)]
+pub struct IncrementAccounts {
+    pub authority: Signer,
+    #[validate(arg = self.authority.pubkey())]
+    pub counter: Mut<ValidatedAccount<CounterAccount>>,
+}
+
+impl StarFrameInstruction for Increment {
+    type ReturnType = ();
+    type Accounts<'b, 'c> = IncrementAccounts;
+
+    fn process(
+        accounts: &mut Self::Accounts<'_, '_>,
+        _run_arg: Self::RunArg<'_>,
+        _ctx: &mut Context,
+    ) -> Result<Self::ReturnType> {
+        let mut counter = accounts.counter.data_mut()?;
+        counter.count += 1;
+        Ok(())
+    }
+}

--- a/cli/src/template/initialize_rs
+++ b/cli/src/template/initialize_rs
@@ -1,0 +1,38 @@
+use crate::states::*;
+use star_frame::prelude::*;
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, InstructionArgs)]
+pub struct InitializeCounter {
+    #[ix_args(&run)]
+    pub start_at: Option<u64>,
+}
+
+#[derive(AccountSet, Debug)]
+pub struct InitializeAccounts {
+    #[validate(funder)]
+    pub authority: Signer<Mut<SystemAccount>>,
+    #[validate(arg = (
+        Create(()),
+        Seeds(CounterAccountSeeds { authority: *self.authority.pubkey() }),
+    ))]
+    #[idl(arg = Seeds(FindCounterSeeds { authority: seed_path("authority") }))]
+    pub counter: Init<Seeded<Account<CounterAccount>>>,
+    pub system_program: Program<System>,
+}
+
+impl StarFrameInstruction for InitializeCounter {
+    type ReturnType = ();
+    type Accounts<'b, 'c> = InitializeAccounts;
+
+    fn process(
+        accounts: &mut Self::Accounts<'_, '_>,
+        start_at: Self::RunArg<'_>,
+        _ctx: &mut Context,
+    ) -> Result<Self::ReturnType> {
+        **accounts.counter.data_mut()? = CounterAccount {
+            authority: *accounts.authority.pubkey(),
+            count: start_at.unwrap_or(0),
+        };
+        Ok(())
+    }
+}

--- a/cli/src/template/instruction_mod_rs
+++ b/cli/src/template/instruction_mod_rs
@@ -1,0 +1,5 @@
+pub mod initialize;
+pub use initialize::*;
+
+pub mod increment;
+pub use increment::*;

--- a/cli/src/template/lib_rs
+++ b/cli/src/template/lib_rs
@@ -1,0 +1,22 @@
+use star_frame::prelude::*;
+
+use instructions::*;
+mod instructions;
+pub mod states;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(StarFrameProgram)]
+#[program(
+    instruction_set = {name_pascalcase}InstructionSet,
+    id = "{pubkey}"
+)]
+pub struct {name_pascalcase}Program;
+
+#[derive(InstructionSet)]
+pub enum {name_pascalcase}InstructionSet {
+    Initialize(InitializeCounter),
+    Increment(Increment),
+}
+

--- a/cli/src/template/states_rs
+++ b/cli/src/template/states_rs
@@ -1,0 +1,22 @@
+use star_frame::{anyhow::ensure, prelude::*};
+
+#[derive(Debug, GetSeeds, Clone)]
+#[get_seeds(seed_const = b"COUNTER")]
+pub struct CounterAccountSeeds {
+    pub authority: Pubkey,
+}
+
+#[derive(Align1, Pod, Zeroable, Default, Copy, Clone, Debug, Eq, PartialEq, ProgramAccount)]
+#[program_account(seeds = CounterAccountSeeds)]
+#[repr(C, packed)]
+pub struct CounterAccount {
+    pub authority: Pubkey,
+    pub count: u64,
+}
+
+impl AccountValidate<&Pubkey> for CounterAccount {
+    fn validate_account(self_ref: &Self::Ref<'_>, arg: &Pubkey) -> Result<()> {
+        ensure!(arg == &self_ref.authority, "Incorrect authority");
+        Ok(())
+    }
+}

--- a/cli/src/template/test_mod_rs
+++ b/cli/src/template/test_mod_rs
@@ -1,0 +1,1 @@
+pub mod counter;


### PR DESCRIPTION
This PR introduces a new command-line interface(CLI) along with a project scaffolding system for quickly generating new Solana programs.

**Features:** 
Subcommands:

- `new`: Generates a full project scaffold including:
  - Base directories (src, instructions, tests)
  - Essential template files (Cargo.toml, .gitignore, lib.rs, instruction modules, and test files)
- `build`: compiling programs
- `test`: running tests 
  - Supports `--nocapture` flag to display test output if necessary

The scaffold generator enhances adoption and accessibility by giving developers a quick start. It includes a counter program that can be easily modified. 
While the team may not have planned a CLI, I implemented one because no existing structure supported this feature. The scaffold generator depends on it to function properly.
