### PR TITLE
Feat: update borsh account and improve complex account initialize

### DIFF
--- a/example_programs/account_test/src/lib.rs
+++ b/example_programs/account_test/src/lib.rs
@@ -37,8 +37,7 @@ pub struct RunAccounts {
     pub funder: Mut<Signer>,
     #[cleanup(arg = NormalizeRent(()))]
     pub account: Mut<Account<AccountData>>,
-    #[decode(arg = || MyBorshAccount { vec: vec![] })]
-    #[validate(arg = Create(()))]
+    #[validate(arg = Create((|| MyBorshAccount::default(), &self.funder,)))]
     #[cleanup(arg = NormalizeRent(()))]
     pub borsh_account: Init<Signer<BorshAccount<MyBorshAccount>>>,
     pub system_program: Program<System>,


### PR DESCRIPTION
`BorshAccount`​ now panics if account is uninitialized and the value is attempted to be read prior to `AccountSetValidate`​. This allows the default creation arg to be in validate like `Account`​

Also updates how complex creation args are passed in to use a closure, which is better on CreateIfNeeded and avoids the conflicting trait implementation