### PR TITLE
removed redundant owner check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Updated CLI template `states_rs`: Changed `AccountValidate` implementation for `CounterAccount` to use `Authority` type parameter instead of `&Pubkey`, and updated reference type from `Self::Ref<'_>` to `Self::Ptr` (#297)
 -   Updated CLI template `initialize_rs`: Changed `Seeds` argument in `idl` macro to use `FindCounterAccountSeeds` instead of `FindCounterSeeds` (#297)
 -   Check the account discriminants during client AccountDeserialize calls (#302)
+-   Removed redundant account owner check during account creation flow (#303)
 
 ### Changed
 

--- a/star_frame/src/account_set/single_set.rs
+++ b/star_frame/src/account_set/single_set.rs
@@ -336,9 +336,6 @@ where
         ctx: &Context,
     ) -> Result<()> {
         let account = *self.account_info();
-        if !account.owner().fast_eq(&System::ID) {
-            bail!(ProgramError::InvalidAccountOwner);
-        }
         let current_lamports = account.lamports();
         let exempt_lamports = ctx.get_rent()?.minimum_balance(space);
 


### PR DESCRIPTION
Saves some CUs on the owner check by having system_create_account fail in system program CPI instead of early