### PR TITLE
maybe remove Seeds<T> and make it T for seeded

### DIFF
--- a/example_programs/counter/src/lib.rs
+++ b/example_programs/counter/src/lib.rs
@@ -62,7 +62,7 @@ pub struct CreateCounterAccounts {
     pub owner: SystemAccount,
     #[validate(arg = (
         CreateIfNeeded(()),
-        Seeds(CounterAccountSeeds { owner: *self.owner.pubkey() }),
+        CounterAccountSeeds { owner: *self.owner.pubkey() },
     ))]
     #[idl(arg = Seeds(FindCounterAccountSeeds { owner: seed_path("owner") }))]
     pub counter: Init<Seeded<WrappedCounter>>,

--- a/example_programs/marketplace/src/instructions/initialize.rs
+++ b/example_programs/marketplace/src/instructions/initialize.rs
@@ -15,10 +15,10 @@ pub struct InitializeAccounts {
     pub market_token: MintAccount,
     #[validate(arg = (
       Create(()),
-      Seeds(MarketSeeds {
+      MarketSeeds {
         currency: *self.currency.key_for(),
         market_token: *self.market_token.key_for()
-      })
+      }
     ))]
     #[idl(
       arg = Seeds(FindMarketSeeds {

--- a/example_programs/simple_counter/src/lib.rs
+++ b/example_programs/simple_counter/src/lib.rs
@@ -53,7 +53,7 @@ pub struct InitializeAccounts {
     pub authority: Signer<Mut<SystemAccount>>,
     #[validate(arg = (
         Create(()),
-        Seeds(CounterSeeds { authority: *self.authority.pubkey() }),
+        CounterSeeds { authority: *self.authority.pubkey() },
     ))]
     #[idl(arg = Seeds(FindCounterSeeds { authority: seed_path("authority") }))]
     pub counter: Init<Seeded<Account<CounterAccount>>>,

--- a/star_frame/src/account_set/borsh_account.rs
+++ b/star_frame/src/account_set/borsh_account.rs
@@ -23,10 +23,10 @@ use crate::{
 /// updated `T` to the account info when the account is writable during `AccountSetCleanup`
 #[derive(AccountSet, Debug, Clone)]
 #[account_set(skip_default_decode, skip_default_idl)]
-#[cfg_attr(feature = "aggressive_inline", 
+#[cfg_attr(feature = "aggressive_inline",
     validate(inline_always, extra_validation = T::validate_account_info(self.info))
 )]
-#[cfg_attr(not(feature = "aggressive_inline"), 
+#[cfg_attr(not(feature = "aggressive_inline"),
     validate(extra_validation = T::validate_account_info(self.info))
 )]
 #[cleanup(generics = [], extra_cleanup = {

--- a/star_frame/src/account_set/impls/account_info.rs
+++ b/star_frame/src/account_set/impls/account_info.rs
@@ -239,15 +239,15 @@ pub mod idl_impl {
         }
     }
 
-    impl<T> AccountSetToIdl<Seeds<(T, Pubkey)>> for AccountInfo
+    impl<T> AccountSetToIdl<(T, Pubkey)> for AccountInfo
     where
         T: FindIdlSeeds,
     {
         fn account_set_to_idl(
             _idl_definition: &mut IdlDefinition,
-            arg: Seeds<(T, Pubkey)>,
+            arg: (T, Pubkey),
         ) -> crate::IdlResult<IdlAccountSetDef> {
-            let (seeds, program) = arg.0;
+            let (seeds, program) = arg;
             Ok(IdlAccountSetDef::Single(IdlSingleAccountSet {
                 seeds: Some(IdlFindSeeds {
                     seeds: T::find_seeds(&seeds)?,
@@ -258,17 +258,17 @@ pub mod idl_impl {
         }
     }
 
-    impl<T> AccountSetToIdl<Seeds<T>> for AccountInfo
+    impl<T> AccountSetToIdl<T> for AccountInfo
     where
         T: FindIdlSeeds,
     {
         fn account_set_to_idl(
             _idl_definition: &mut IdlDefinition,
-            arg: Seeds<T>,
+            arg: T,
         ) -> crate::IdlResult<IdlAccountSetDef> {
             Ok(IdlAccountSetDef::Single(IdlSingleAccountSet {
                 seeds: Some(IdlFindSeeds {
-                    seeds: T::find_seeds(&arg.0)?,
+                    seeds: T::find_seeds(&arg)?,
                     program: None,
                 }),
                 ..Default::default()

--- a/star_frame/src/account_set/mod.rs
+++ b/star_frame/src/account_set/mod.rs
@@ -424,6 +424,7 @@ pub(crate) mod prelude {
         discriminant, Account, CloseAccount, NormalizeRent, ReceiveRent, RefundRent,
     };
     pub use borsh_account::BorshAccount;
+    #[allow(deprecated)]
     pub use modifiers::{
         init::{Create, CreateIfNeeded, Init},
         mutable::Mut,


### PR DESCRIPTION
#### Problem

The `Seeds` wrapper type in the `star_frame` crate is redundant and adds unnecessary complexity to the API. Developers need to wrap seed structs with `Seeds(...)` when they could just use the seed structs directly.

#### Summary of Changes

- Deprecated the `Seeds<T>` wrapper type with a note that it's no longer required
- Added direct validation implementations that accept seed structs without the wrapper
- Updated example programs to use the new simplified syntax
- Maintained backward compatibility by keeping the old implementations
- Added appropriate IDL implementations for the new validation methods

Fixes #

---

- [ ] I updated the [CHANGELOG.md](/CHANGELOG.md) file in the root with my changes