### PR TITLE
Chore: bump rust versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,13 @@ permissions:
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
-    branches: ['main']
+    branches: ["main"]
     types: [synchronize, opened, reopened]
 
 env:
-  rust_miri_nightly: 'nightly-2025-06-15'
+  rust_miri_nightly: "nightly-2025-12-08"
 defaults:
   run:
     shell: bash
@@ -32,13 +32,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache: 'false'
+          cache: "false"
       - run: cargo fmt --all --check
 
   doc:
     runs-on: warp-ubuntu-latest-x64-4x
     env:
-      RUSTDOCFLAGS: '-Dwarnings'
+      RUSTDOCFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # Check https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
 # for valid toolchains.
 # Older ones can be found at https://github.com/oxalica/rust-overlay/tree/master/manifests/nightly
-channel = "1.89.0"
+channel = "1.90.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Bumps rust-toolchain.toml to support latest rust-analyzer, and updates the pinned nightly version for MIRI CI